### PR TITLE
Added Client object, Users.company, Projects.client

### DIFF
--- a/alembic/versions/182f44ce5f07_added_users_company_and_projects_client.py
+++ b/alembic/versions/182f44ce5f07_added_users_company_and_projects_client.py
@@ -1,0 +1,240 @@
+"""added Users.company and Projects.client columns and a new Clients table
+
+Revision ID: 182f44ce5f07
+Revises: 59bfe820c369
+Create Date: 2014-05-29 11:33:02.313000
+
+"""
+
+
+
+# revision identifiers, used by Alembic.
+revision = '182f44ce5f07'
+down_revision = '59bfe820c369'
+
+from alembic import op
+import sqlalchemy as sa
+
+def upgrade():
+
+    # Create Clients table
+    op.create_table('Clients',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['id'], ['Entities.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+    # Create Client_Users table
+    op.create_table('Client_Users',
+    sa.Column('uid', sa.Integer(), nullable=False),
+    sa.Column('did', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['did'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['uid'], ['Users.id'], ),
+    sa.PrimaryKeyConstraint('uid', 'did')
+    )
+
+    # Create Client_Projects table
+    op.create_table('Client_Projects',
+    sa.Column('uid', sa.Integer(), nullable=False),
+    sa.Column('did', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['did'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['uid'], ['Projects.id'], ),
+    sa.PrimaryKeyConstraint('uid', 'did')
+    )
+
+
+    # Users table
+    op.add_column('Users', sa.Column('company_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(name=None, source='Users', referent='Clients', local_cols=['company_id'], remote_cols=['id'])
+
+    # Projects table
+    op.add_column('Projects', sa.Column('client_id', sa.Integer(), nullable=True))
+    op.create_foreign_key(name=None, source='Projects', referent='Clients', local_cols=['client_id'], remote_cols=['id'])
+
+
+
+    '''
+
+    #
+    # Original alembic-generated code below
+    #
+
+    op.create_table('Clients',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['id'], ['Entities.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+    op.create_table('Users',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('company_id', sa.Integer(), nullable=True),
+    sa.Column('email', sa.String(length=256), nullable=False),
+    sa.Column('password', sa.String(length=256), nullable=False),
+    sa.Column('last_login', sa.DateTime(), nullable=True),
+    sa.Column('login', sa.String(length=256), nullable=False),
+    sa.Column('efficiency', sa.Float(), nullable=True),
+    sa.ForeignKeyConstraint(['company_id'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['id'], ['Entities.id'], ),
+    sa.PrimaryKeyConstraint('id'),
+    sa.UniqueConstraint('email'),
+    sa.UniqueConstraint('login')
+    )
+
+
+    op.create_table('Projects',
+    sa.Column('id', sa.Integer(), nullable=False),
+    sa.Column('active', sa.Boolean(), nullable=True),
+    sa.Column('client_id', sa.Integer(), nullable=True),
+    sa.Column('lead_id', sa.Integer(), nullable=True),
+    sa.Column('repository_id', sa.Integer(), nullable=True),
+    sa.Column('structure_id', sa.Integer(), nullable=True),
+    sa.Column('image_format_id', sa.Integer(), nullable=True),
+    sa.Column('fps', sa.Float(precision=3), nullable=True),
+    sa.Column('is_stereoscopic', sa.Boolean(), nullable=True),
+    sa.Column('status_id', sa.Integer(), nullable=False),
+    sa.Column('status_list_id', sa.Integer(), nullable=False),
+    sa.Column('start', sa.DateTime(), nullable=True),
+    sa.Column('duration', sa.Interval(), nullable=True),
+    sa.Column('computed_end', sa.DateTime(), nullable=True),
+    sa.Column('computed_start', sa.DateTime(), nullable=True),
+    sa.Column('end', sa.DateTime(), nullable=True),
+    sa.Column('code', sa.String(length=256), nullable=False),
+    sa.ForeignKeyConstraint(['client_id'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['id'], ['Entities.id'], ),
+    sa.ForeignKeyConstraint(['image_format_id'], ['ImageFormats.id'], ),
+    sa.ForeignKeyConstraint(['lead_id'], ['Users.id'], ),
+    sa.ForeignKeyConstraint(['repository_id'], ['Repositories.id'], ),
+    sa.ForeignKeyConstraint(['status_id'], ['Statuses.id'], ),
+    sa.ForeignKeyConstraint(['status_list_id'], ['StatusLists.id'], ),
+    sa.ForeignKeyConstraint(['structure_id'], ['Structures.id'], ),
+    sa.PrimaryKeyConstraint('id')
+    )
+
+
+    op.create_table('Client_Users',
+    sa.Column('uid', sa.Integer(), nullable=False),
+    sa.Column('did', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['did'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['uid'], ['Users.id'], ),
+    sa.PrimaryKeyConstraint('uid', 'did')
+    )
+
+
+    op.create_table('Client_Projects',
+    sa.Column('uid', sa.Integer(), nullable=False),
+    sa.Column('did', sa.Integer(), nullable=False),
+    sa.ForeignKeyConstraint(['did'], ['Clients.id'], ),
+    sa.ForeignKeyConstraint(['uid'], ['Projects.id'], ),
+    sa.PrimaryKeyConstraint('uid', 'did')
+    )
+    '''
+
+
+
+
+def downgrade():
+
+
+    op.drop_constraint(name='users_ibfk_2', type_='foreignkey', table_name='Users')
+    op.drop_column('Users', 'company_id')
+
+    op.drop_constraint(name='projects_ibfk_8', type_='foreignkey', table_name='Projects')
+    op.drop_column('Projects', 'client_id')
+
+    op.drop_table('Client_Projects')
+    op.drop_table('Client_Users')
+    op.drop_table('Clients')
+
+
+    '''
+
+    #
+    # Original alembic-generated code below
+    #
+
+    op.create_table('projects',
+    sa.Column('id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('active', mysql.TINYINT(display_width=1), autoincrement=False, nullable=True),
+    sa.Column('client_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('lead_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('repository_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('structure_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('image_format_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('fps', mysql.FLOAT(), nullable=True),
+    sa.Column('is_stereoscopic', mysql.TINYINT(display_width=1), autoincrement=False, nullable=True),
+    sa.Column('status_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('status_list_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('start', mysql.DATETIME(), nullable=True),
+    sa.Column('duration', mysql.DATETIME(), nullable=True),
+    sa.Column('computed_end', mysql.DATETIME(), nullable=True),
+    sa.Column('computed_start', mysql.DATETIME(), nullable=True),
+    sa.Column('end', mysql.DATETIME(), nullable=True),
+    sa.Column('code', mysql.VARCHAR(length=256), nullable=False),
+    sa.ForeignKeyConstraint(['client_id'], [u'clients.id'], name=u'projects_ibfk_2'),
+    sa.ForeignKeyConstraint(['id'], [u'entities.id'], name=u'projects_ibfk_1'),
+    sa.ForeignKeyConstraint(['image_format_id'], [u'imageformats.id'], name=u'projects_ibfk_6'),
+    sa.ForeignKeyConstraint(['lead_id'], [u'users.id'], name=u'projects_ibfk_3'),
+    sa.ForeignKeyConstraint(['repository_id'], [u'repositories.id'], name=u'projects_ibfk_4'),
+    sa.ForeignKeyConstraint(['status_id'], [u'statuses.id'], name=u'projects_ibfk_7'),
+    sa.ForeignKeyConstraint(['status_list_id'], [u'statuslists.id'], name=u'projects_ibfk_8'),
+    sa.ForeignKeyConstraint(['structure_id'], [u'structures.id'], name=u'projects_ibfk_5'),
+    sa.PrimaryKeyConstraint('id'),
+    mysql_default_charset=u'latin1',
+    mysql_engine=u'InnoDB'
+    )
+
+
+    op.create_table('client_users',
+    sa.Column('uid', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('did', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.ForeignKeyConstraint(['did'], [u'clients.id'], name=u'client_users_ibfk_2'),
+    sa.ForeignKeyConstraint(['uid'], [u'users.id'], name=u'client_users_ibfk_1'),
+    sa.PrimaryKeyConstraint('uid', 'did'),
+    mysql_default_charset=u'latin1',
+    mysql_engine=u'InnoDB'
+    )
+
+
+    op.create_table('users',
+    sa.Column('id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('company_id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=True),
+    sa.Column('email', mysql.VARCHAR(length=256), nullable=False),
+    sa.Column('password', mysql.VARCHAR(length=256), nullable=False),
+    sa.Column('last_login', mysql.DATETIME(), nullable=True),
+    sa.Column('login', mysql.VARCHAR(length=256), nullable=False),
+    sa.Column('efficiency', mysql.FLOAT(), nullable=True),
+    sa.ForeignKeyConstraint(['company_id'], [u'clients.id'], name=u'users_ibfk_2'),
+    sa.ForeignKeyConstraint(['id'], [u'entities.id'], name=u'users_ibfk_1'),
+    sa.PrimaryKeyConstraint('id'),
+    mysql_default_charset=u'latin1',
+    mysql_engine=u'InnoDB'
+    )
+
+
+    op.create_table('clients',
+    sa.Column('id', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.ForeignKeyConstraint(['id'], [u'entities.id'], name=u'clients_ibfk_1'),
+    sa.PrimaryKeyConstraint('id'),
+    mysql_default_charset=u'latin1',
+    mysql_engine=u'InnoDB'
+    )
+
+
+    op.create_table('client_projects',
+    sa.Column('uid', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.Column('did', mysql.INTEGER(display_width=11), autoincrement=False, nullable=False),
+    sa.ForeignKeyConstraint(['did'], [u'clients.id'], name=u'client_projects_ibfk_2'),
+    sa.ForeignKeyConstraint(['uid'], [u'projects.id'], name=u'client_projects_ibfk_1'),
+    sa.PrimaryKeyConstraint('uid', 'did'),
+    mysql_default_charset=u'latin1',
+    mysql_engine=u'InnoDB'
+    )
+
+
+    op.drop_table('Client_Projects')
+    op.drop_table('Client_Users')
+    op.drop_table('Clients')
+
+    '''
+
+

--- a/docs/source/inheritance_diagram.rst
+++ b/docs/source/inheritance_diagram.rst
@@ -17,6 +17,7 @@ Inheritance Diagram
    stalker.models.auth.RootFactory
    stalker.models.auth.User
    stalker.models.department.Department
+   stalker.models.client.Client
    stalker.models.entity.Entity
    stalker.models.entity.SimpleEntity
    stalker.models.format.ImageFormat

--- a/docs/source/summary.rst
+++ b/docs/source/summary.rst
@@ -23,6 +23,7 @@ Summary
    stalker.models.auth.RootFactory
    stalker.models.auth.User
    stalker.models.department.Department
+   stalker.models.client.Client
    stalker.models.entity.Entity
    stalker.models.entity.SimpleEntity
    stalker.models.format.ImageFormat

--- a/stalker/__init__.py
+++ b/stalker/__init__.py
@@ -32,6 +32,7 @@ from stalker.config import defaults
 from stalker.models.auth import Group, Permission, User, LocalSession
 from stalker.models.asset import Asset
 from stalker.models.department import Department
+from stalker.models.client import Client
 from stalker.models.entity import SimpleEntity, Entity
 from stalker.models.format import ImageFormat
 from stalker.models.link import Link

--- a/stalker/db/__init__.py
+++ b/stalker/db/__init__.py
@@ -94,7 +94,7 @@ def init():
 
     # register all Actions available for all SOM classes
     class_names = [
-        'Asset', 'TimeLog', 'Department', 'Entity', 'FilenameTemplate',
+        'Asset', 'TimeLog', 'Client', 'Department', 'Entity', 'FilenameTemplate',
         'Group', 'ImageFormat', 'Link', 'Message', 'Note', 'Page',
         'Permission', 'Project', 'Repository', 'Review', 'Scene', 'Sequence',
         'Shot', 'SimpleEntity', 'Status', 'StatusList', 'Structure', 'Studio',

--- a/stalker/models/client.py
+++ b/stalker/models/client.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+# Stalker a Production Asset Management System
+# Copyright (C) 2009-2014 Erkan Ozgur Yilmaz
+#
+# This file is part of Stalker.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation;
+# version 2.1 of the License.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+from sqlalchemy import Table, Column, Integer, ForeignKey
+from sqlalchemy.orm import relationship, validates, synonym
+
+from stalker import defaults
+from stalker.models.auth import User
+from stalker.models.entity import Entity
+from stalker.models.project import Project
+
+from stalker.db.declarative import Base
+
+from stalker.log import logging_level
+import logging
+logger = logging.getLogger(__name__)
+logger.setLevel(logging_level)
+
+
+class Client(Entity):
+    """The Client (e.g. a company) which users may be part of.
+
+    The information that a Client object holds is like:
+
+      * The users of the client
+      * The projects affiliated with the client
+      * and all the other things those are inherited from the AuditEntity class
+
+    Two Client object considered the same if they have the same name.
+
+    so creating a client object needs the following parameters:
+
+    :param users: it can be an empty list, so one client can be created
+      without any user in it. But this parameter should be a list of User
+      objects.
+
+    :type users: list of :class:`.Client`\ s
+    
+    :param projects: it can be an empty list, so one client can be created
+      without any project in it. But this parameter should be a list of Project
+      objects.
+
+    :type projects: :param type: list of :class:`.Project`\ s
+
+    """
+    __auto_name__ = False
+    __tablename__ = "Clients"
+    __mapper_args__ = {"polymorphic_identity": "Client"}
+    client_id = Column(
+        "id",
+        Integer,
+        ForeignKey("Entities.id"),
+        primary_key=True
+    )
+
+    users = relationship(
+        "User",
+        secondary='Client_Users',
+        back_populates="company",
+        doc="""List of users representing the employees of this client.""",
+    )
+
+    projects = relationship(
+        "Project",
+        secondary='Client_Projects',
+        back_populates="client",
+        doc="""List of projects affiliated with this client.""",
+    )
+
+
+    members = synonym('users')
+
+
+    def __init__(
+            self,
+            users=None,
+            projects=None,
+            **kwargs):
+
+
+        super(Client, self).__init__(**kwargs)
+
+        if users is None:
+            users = []
+        if projects is None:
+            projects = []
+
+        self.users = users
+        self.projects = projects
+
+    def __eq__(self, other):
+        """the equality operator
+        """
+        return super(Client, self).__eq__(other) and \
+            isinstance(other, Client)
+
+    @validates("users")
+    def _validate_users(self, key, user):
+        """validates the given user attribute
+        """
+        from stalker.models.auth import User
+
+        if not isinstance(user, User):
+            raise TypeError(
+                "Every element in the %s.users list should be an instance "
+                "of stalker.models.auth.User not %s" %
+                (self.__class__.__name__, user.__class__.__name__)
+            )
+        return user
+
+    @validates("projects")
+    def _validate_projects(self, key, project):
+        """validates the given project attribute
+        """
+        from stalker.models.project import Project
+
+        if not isinstance(project, Project):
+            raise TypeError(
+                "Every element in the %s.projects list should be an instance "
+                "of stalker.models.project.Project not %s" %
+                (self.__class__.__name__, project.__class__.__name__)
+            )
+        return project
+
+
+
+
+
+Client_Users = Table(
+    'Client_Users', Base.metadata,
+    Column('uid', Integer, ForeignKey('Users.id'), primary_key=True),
+    Column('did', Integer, ForeignKey('Clients.id'), primary_key=True)
+)
+
+Client_Projects = Table(
+    'Client_Projects', Base.metadata,
+    Column('uid', Integer, ForeignKey('Projects.id'), primary_key=True),
+    Column('did', Integer, ForeignKey('Clients.id'), primary_key=True)
+)

--- a/tests/models/test_client.py
+++ b/tests/models/test_client.py
@@ -1,0 +1,424 @@
+# -*- coding: utf-8 -*-
+# Stalker a Production Asset Management System
+# Copyright (C) 2009-2014 Erkan Ozgur Yilmaz
+#
+# This file is part of Stalker.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation;
+# version 2.1 of the License.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+import unittest2
+import datetime
+from stalker import Client, Entity, User, Project, Status, StatusList, Repository
+
+
+class ClientTester(unittest2.TestCase):
+    """tests the Client class
+    """
+
+    def setUp(self):
+        """lets setup the tests
+        """
+        # create a couple of test users
+        self.test_user1 = User(
+            name="User1",
+            login="user1",
+            email="user1@test.com",
+            password="123456",
+        )
+
+        self.test_user2 = User(
+            name="User2",
+            login="user2",
+            email="user2@test.com",
+            password="123456",
+        )
+
+        self.test_user3 = User(
+            name="User3",
+            login="user3",
+            email="user3@test.com",
+            password="123456",
+        )
+
+        self.test_user4 = User(
+            name="User4",
+            login="user4",
+            email="user4@test.com",
+            password="123456",
+        )
+
+        self.users_list = [
+            self.test_user1,
+            self.test_user2,
+            self.test_user3,
+            self.test_user4
+        ]
+
+        self.test_admin = User(
+            name="admin",
+            login="admin",
+            email="admin@test.com",
+            password="admin",
+        )
+
+
+
+        self.status_new = Status(name="Test status 1", code="Status1")
+        self.status_wip = Status(name="Test status 1", code="Status2")
+        self.status_cmpl = Status(name="Test status 1", code="Status3")
+
+        self.project_statuses = StatusList(
+            name="Project Status List",
+            statuses=[
+                self.status_new,
+                self.status_wip,
+                self.status_cmpl
+            ],
+            target_entity_type=Project  # you can also use "Project" which is a str
+        )
+
+
+        self.test_repo = Repository(
+          name="Test Repository"
+        )
+
+        self.test_project1 = Project(
+            name="Test Project 1",
+            code='proj1',
+            status_list=self.project_statuses,
+            repository=self.test_repo,
+        )
+
+
+        self.test_project2 = Project(
+            name="Test Project 1",
+            code='proj2',
+            status_list=self.project_statuses,
+            repository=self.test_repo,
+        )
+
+
+        self.test_project3 = Project(
+            name="Test Project 1",
+            code='proj3',
+            status_list=self.project_statuses,
+            repository=self.test_repo,
+        )
+
+        self.projects_list = [
+            self.test_project1,
+            self.test_project2,
+            self.test_project3
+
+        ]
+
+
+        self.date_created = self.date_updated = datetime.datetime.now()
+
+        self.kwargs = {
+            "name": "Test Client",
+            "description": "This is a client for testing purposes",
+            "created_by": self.test_admin,
+            "updated_by": self.test_admin,
+            "date_created": self.date_created,
+            "date_updated": self.date_updated,
+            "users": self.users_list,
+            "projects": self.projects_list
+        }
+
+        # create a default client object
+        self.test_client = Client(**self.kwargs)
+
+        # assign company
+
+
+
+
+
+    def test___auto_name__class_attribute_is_set_to_false(self):
+        """testing if the __auto_name__ class attribute is set to False for
+        Department class
+        """
+        self.assertFalse(Client.__auto_name__)
+
+    def test_users_argument_accepts_an_empty_list(self):
+        """testing if users argument accepts an empty list
+        """
+        # this should work without raising any error
+        self.kwargs["users"] = []
+        new_dep = Client(**self.kwargs)
+        self.assertIsInstance(new_dep, Client)
+
+    def test_users_attribute_accepts_an_empty_list(self):
+        """testing if users attribute accepts an empty list
+        """
+        # this should work without raising any error
+        self.test_client.users = []
+
+    def test_users_argument_accepts_only_a_list_of_user_objects(self):
+        """testing if users argument accepts only a list of user objects
+        """
+        test_value = [1, 2.3, [], {}]
+        self.kwargs["users"] = test_value
+        # this should raise a TypeError
+        self.assertRaises(
+            TypeError,
+            Client,
+            **self.kwargs
+        )
+
+    def test_users_attribute_accepts_only_a_list_of_user_objects(self):
+        """testing if users attribute accepts only a list of user objects
+        """
+        test_value = [1, 2.3, [], {}]
+        # this should raise a TypeError
+        self.assertRaises(
+            TypeError,
+            setattr,
+            self.test_client,
+            "users",
+            test_value
+        )
+
+    def test_users_attribute_elements_accepts_User_only(self):
+        """testing if a TypeError will be raised when trying to assign
+        something other than a User object to the users list
+        """
+        # append
+        self.assertRaises(
+            TypeError,
+            self.test_client.users.append,
+            0
+        )
+
+        # __setitem__
+        self.assertRaises(
+            TypeError,
+            self.test_client.users.__setitem__,
+            0,
+            0
+        )
+
+    def test_users_argument_is_not_iterable(self):
+        """testing if a TypeError will be raised when the given users
+        argument is not an instance of list
+        """
+        test_values = [1, 1.2, "a user"]
+        for test_value in test_values:
+            self.kwargs["users"] = test_value
+            self.assertRaises(TypeError, Client, **self.kwargs)
+
+    def test_users_attribute_is_not_iterable(self):
+        """testing if a TypeError will be raised when the users attribute
+        is tried to be set to a non-iterable value
+        """
+        test_values = [1, 1.2, "a user"]
+        for test_value in test_values:
+            self.assertRaises(TypeError, setattr, self.test_client,
+                              "users", test_value)
+
+    def test_users_attribute_defaults_to_empty_list(self):
+        """testing if the users attribute defaults to an empty list if the
+         users argument is skipped
+        """
+        self.kwargs.pop("users")
+        new_client = Client(**self.kwargs)
+        self.assertEqual(new_client.users, [])
+
+    def test_users_attribute_set_to_None(self):
+        """testing if a TypeError will be raised when the users attribute is
+        set to None
+        """
+        self.assertRaises(TypeError, setattr, self.test_client, "users",
+                          None)
+
+    def test_members_attribute_is_a_synonym_for_users(self):
+        """testing if the members attribute is actually a synonym for the users
+        attribute
+        """
+        self.assertEqual(self.test_client.users,
+                         self.test_client.members)
+
+    def test_projects_argument_accepts_an_empty_list(self):
+        """testing if projects argument accepts an empty list
+        """
+        # this should work without raising any error
+        self.kwargs["projects"] = []
+        new_dep = Client(**self.kwargs)
+        self.assertIsInstance(new_dep, Client)
+
+    def test_projects_attribute_accepts_an_empty_list(self):
+        """testing if projects attribute accepts an empty list
+        """
+        # this should work without raising any error
+        self.test_client.projects = []
+
+    def test_projects_argument_accepts_only_a_list_of_project_objects(self):
+        """testing if projects argument accepts only a list of project objects
+        """
+        test_value = [1, 2.3, [], {}]
+        self.kwargs["projects"] = test_value
+        # this should raise a TypeError
+        self.assertRaises(
+            TypeError,
+            Client,
+            **self.kwargs
+        )
+
+    def test_projects_attribute_accepts_only_a_list_of_project_objects(self):
+        """testing if users attribute accepts only a list of project objects
+        """
+        test_value = [1, 2.3, [], {}]
+        # this should raise a TypeError
+        self.assertRaises(
+            TypeError,
+            setattr,
+            self.test_client,
+            "projects",
+            test_value
+        )
+
+
+    def test_projects_attribute_elements_accepts_Project_only(self):
+        """testing if a TypeError will be raised when trying to assign
+        something other than a Project object to the projects list
+        """
+        # append
+        self.assertRaises(
+            TypeError,
+            self.test_client.projects.append,
+            0
+        )
+
+        # __setitem__
+        self.assertRaises(
+            TypeError,
+            self.test_client.projects.__setitem__,
+            0,
+            0
+        )
+
+    def test_projects_argument_is_not_iterable(self):
+        """testing if a TypeError will be raised when the given projects
+        argument is not an instance of list
+        """
+        test_values = [1, 1.2, "a project"]
+        for test_value in test_values:
+            self.kwargs["projects"] = test_value
+            self.assertRaises(TypeError, Project, **self.kwargs)
+
+
+    def test_projects_attribute_is_not_iterable(self):
+        """testing if a TypeError will be raised when the projects attribute
+        is tried to be set to a non-iterable value
+        """
+        test_values = [1, 1.2, "a project"]
+        for test_value in test_values:
+            self.assertRaises(TypeError, setattr, self.test_client,
+                              "projects", test_value)
+
+    def test_projects_attribute_defaults_to_empty_list(self):
+        """testing if the projects attribute defaults to an empty list if the
+         projects argument is skipped
+        """
+        self.kwargs.pop("projects")
+        new_client = Client(**self.kwargs)
+        self.assertEqual(new_client.projects, [])
+
+    def test_projects_attribute_set_to_None(self):
+        """testing if a TypeError will be raised when the projects attribute is
+        set to None
+        """
+        self.assertRaises(TypeError, setattr, self.test_client, "projects",
+                          None)
+
+    def test_user_remove_also_removes_client_from_user(self):
+        """testing if removing an user from the users list also removes the
+        client from the users company argument
+        """
+
+        # check if the user is in the company
+        self.assertIs(self.test_client, self.test_user1.company)
+
+        # now remove the user from the company
+        self.test_client.users.remove(self.test_user1)
+
+        # now check if company is not in users departments anymore
+        self.assertIsNot(self.test_client, self.test_user1.company)
+
+        # assign the user back
+        self.test_user1.company = self.test_client
+
+        # check if the user is in the companys users list
+        self.assertIn(self.test_user1, self.test_client.users)
+
+
+    def test_project_remove_also_removes_project_from_client(self):
+        """testing if removing an user from the users list also removes the
+        client from the users company argument
+        """
+
+        # check if the project is registered with the client
+        self.assertIs(self.test_project1.client, self.test_client)
+
+        # now remove the project from the client
+        self.test_client.projects.remove(self.test_project1)
+
+        # now check if project no longer belongs to client
+        self.assertIsNot(self.test_project1, self.test_client.projects)
+
+        # assign the project back
+        self.test_client.projects.append(self.test_project1)
+
+        # check if the project is in the companys projects list
+        self.assertIn(self.test_project1, self.test_client.projects)
+
+
+    def test_equality(self):
+        """testing equality of two Client objects
+        """
+        dep1 = Client(**self.kwargs)
+        dep2 = Client(**self.kwargs)
+
+        entity_kwargs = self.kwargs.copy()
+        entity_kwargs.pop("users")
+        entity_kwargs.pop("projects")
+        entity1 = Entity(**entity_kwargs)
+
+        self.kwargs["name"] = "Company X"
+        dep3 = Client(**self.kwargs)
+
+        self.assertTrue(dep1 == dep2)
+        self.assertFalse(dep1 == dep3)
+        self.assertFalse(dep1 == entity1)
+
+    def test_inequality(self):
+        """testing inequality of two Client objects
+        """
+        dep1 = Client(**self.kwargs)
+        dep2 = Client(**self.kwargs)
+
+        entity_kwargs = self.kwargs.copy()
+        entity_kwargs.pop("users")
+        entity_kwargs.pop("projects")
+        entity1 = Entity(**entity_kwargs)
+
+        self.kwargs["name"] = "Company X"
+        dep3 = Client(**self.kwargs)
+
+        self.assertFalse(dep1 != dep2)
+        self.assertTrue(dep1 != dep3)
+        self.assertTrue(dep1 != entity1)
+

--- a/tests/models/test_project.py
+++ b/tests/models/test_project.py
@@ -25,7 +25,7 @@ from stalker import log
 from stalker.db.session import DBSession
 from stalker import (db, Asset, Entity, ImageFormat, Link, Project, Repository,
                      Sequence, Shot, Status, StatusList, Structure, Task, Type,
-                     User, Ticket)
+                     User, Ticket, Client)
 import logging
 
 logger = logging.getLogger('stalker.models.project')
@@ -140,6 +140,13 @@ class ProjectTestCase(unittest2.TestCase):
             password="123456"
         )
 
+        self.test_userClient = User(
+            name="User Client",
+            login="userClient",
+            email="user@client.com",
+            password="123456"
+        )
+
         # statuses
         self.status_new = Status(name="New", code="NEW")
         self.status_wfd = Status(name="Waiting For Dependency", code="WFD")
@@ -209,6 +216,10 @@ class ProjectTestCase(unittest2.TestCase):
             name="Commercials Repository",
         )
 
+
+        self.test_client = Client(name='Test Company', users=[self.test_userClient])
+
+
         # create a project object
         self.kwargs = {
             "name": "Test Project",
@@ -224,7 +235,8 @@ class ProjectTestCase(unittest2.TestCase):
             "display_width": 15,
             "start": self.start,
             "end": self.end,
-            "status_list": self.project_status_list
+            "status_list": self.project_status_list,
+            "client": self.test_client
         }
 
         self.test_project = Project(**self.kwargs)
@@ -683,6 +695,7 @@ class ProjectTestCase(unittest2.TestCase):
 
         DBSession.add(self.test_project)
         DBSession.commit()
+
 
     def test___auto_name__class_attribute_is_set_to_False(self):
         """testing if the __auto_name__ class attribute is set to False for
@@ -2188,3 +2201,32 @@ class ProjectTicketsTestCase(unittest2.TestCase):
                 self.test_ticket8
             ]
         )
+    
+
+    
+    def test_client_argument_is_given_as_something_other_than_a_client(self):
+        """testing if a TypeError will be raised when the client argument is
+        given as something other than a Client object
+        """
+        test_values = [1, 1.2, "a user", ["a", "user"], {"a": "user"}]
+
+        for test_value in test_values:
+            self.kwargs["client"] = test_value
+            self.assertRaises(
+                TypeError,
+                Project,
+                **self.kwargs
+            )
+
+    def test_client_argument_is_skipped(self):
+        """testing if the client attribute will be set to None when the client
+        argument is skipped
+        """
+        self.kwargs['name'] = 'New Project Name'
+        try:
+            self.kwargs.pop('client')
+        except KeyError:
+            pass
+        new_project = Project(**self.kwargs)
+        self.assertEquals(new_project.client, None)
+        

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -26,7 +26,7 @@ import logging
 from stalker.db.session import DBSession
 from stalker import (db, defaults, Group, Department, Project, Repository,
                      Sequence, Status, StatusList, Task, Type, User, Version,
-                     Ticket, Vacation)
+                     Ticket, Vacation, Client)
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
@@ -419,6 +419,9 @@ class UserTest(unittest2.TestCase):
             .first()
         self.assertIsNotNone(self.test_admin)
 
+        # create test company
+        self.test_company = Client(name='Test Company')
+
         # create the default values for parameters
         self.kwargs = {
             'name': 'Erkan Ozgur Yilmaz',
@@ -431,7 +434,8 @@ class UserTest(unittest2.TestCase):
                        self.test_group2],
             'created_by': self.test_admin,
             'updated_by': self.test_admin,
-            'efficiency': 1.0
+            'efficiency': 1.0,
+            'company': self.test_company
         }
 
         # create a proper user object
@@ -443,6 +447,7 @@ class UserTest(unittest2.TestCase):
         self.kwargs['name'] = 'some other name'
         self.kwargs['email'] = 'some@other.email'
 
+    
     def tearDown(self):
         """tear down the test
         """
@@ -1464,3 +1469,29 @@ class UserTest(unittest2.TestCase):
             2.3,
             self.test_user.efficiency
         )
+
+
+    def test_client_argument_is_given_as_something_other_than_a_client(self):
+        """testing if a TypeError will be raised when the client argument is
+        given as something other than a Client object
+        """
+        test_values = [1, 1.2, "a user", ["a", "user"], {"a": "user"}]
+
+        for test_value in test_values:
+            self.kwargs["company"] = test_value
+            self.assertRaises(
+                TypeError,
+                User,
+                **self.kwargs
+            )
+
+    def test_company_argument_is_skipped(self):
+        """testing if the company attribute will be set to None when the company
+        argument is skipped
+        """
+        try:
+            self.kwargs.pop('company')
+        except KeyError:
+            pass
+        new_user = User(**self.kwargs)
+        self.assertEquals(new_user.company, None)


### PR DESCRIPTION
Adds a new Client object, which can hold users and projects. This is a great way of registering companies which assign your studio with projects.

Upon creation of a Client, you can (optionally) add users and projects to it.

A user can be created in stalker and be assigned to the Client. Also, a project can be created and be assigned to the Client.

Tests and Alembic revision included, although I found the Alembic removal of foreign keys a bit sketchy. Not sure if the Alembic revision containing the foreign key removals in `downgrade()` could be done in a better way. Right now, the foreign key name is specified and if not found, it will generate an error on downgrade. Ideally I would have wanted all foreign keys to be dropped when the columns (Users.company, Projects.client) are dropped.
