### PR TITLE
Removed str() conversion from nice_name_in

### DIFF
--- a/stalker/models/entity.py
+++ b/stalker/models/entity.py
@@ -395,7 +395,7 @@ class SimpleEntity(Base):
         """formats the given nice name
         """
         # remove unnecessary characters from the string
-        nice_name_in = str(nice_name_in).strip()
+        nice_name_in = nice_name_in.strip()
         nice_name_in = re.sub(r'([^a-zA-Z0-9\s_\-]+)', '',
                               nice_name_in).strip()
 


### PR DESCRIPTION
When I remove the string conversion in `_format_nice_name`, I can now successfully add projects with unicode characters without issues.

I performed testing of `test_entity.py` and I received some errors which I have problems tracking down... I'm not sure what causes them. I'm creating a separate issue for that.
