### PR TITLE
Added TaskJuggler to Travis testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
       - psql --version
       - pg_config --version
       - tj3 --version
-      - ln -s $(which tj3) /usr/local/bin/tj3
+      - sudo ln -s $(which tj3) /usr/local/bin/tj3
       - psql -c "CREATE DATABASE stalker_test;" -U postgres
       - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@
       - psql --version
       - pg_config --version
       - tj3 --version
+      - which tj3
       - psql -c "CREATE DATABASE stalker_test;" -U postgres
       - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@
     addons:
       postgresql: "9.4"
 
-    before-install:
+    before_install:
       - sudo apt-get -qq update
       - sudo apt-get install -y tj3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,8 @@
     addons:
       postgresql: "9.4"
 
-    before_install:
-      - sudo apt-get -qq update
-      - sudo apt-get install -y tj3
-
     install:
+      - gem install taskjuggler
       - pip install sqlalchemy psycopg2 jinja2 alembic Mako MarkupSafe python-editor nose coverage
 
     before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@
     addons:
       postgresql: "9.4"
 
+    before-install:
+      - sudo apt-get install -y tj3
+
     install:
       - pip install sqlalchemy psycopg2 jinja2 alembic Mako MarkupSafe python-editor nose coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@
       - postgresql
 
     addons:
-      postgresql: "9.4"
+      postgresql: "9.3"
 
     install:
       - gem install taskjuggler
@@ -20,6 +20,7 @@
     before_script:
       - psql --version
       - pg_config --version
+      - tj3 --version
       - psql -c "CREATE DATABASE stalker_test;" -U postgres
       - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@
       - psql --version
       - pg_config --version
       - tj3 --version
-      - which tj3
+      - ln -s $(which tj3) /usr/local/bin/tj3
       - psql -c "CREATE DATABASE stalker_test;" -U postgres
       - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@
       postgresql: "9.4"
 
     before-install:
+      - sudo apt-get -qq update
       - sudo apt-get install -y tj3
 
     install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,4 @@
       - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 
     script:
-      - nosetests $@ --verbosity=1 --cover-erase --with-coverage --cover-package=stalker
+      - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker


### PR DESCRIPTION
Some nosetests errors were [fixed](https://travis-ci.org/fredrikaverpil/stalker/jobs/201241308) by installing TaskJuggler and symlinking its binary to the path where Stalker is expecting it to be on Unix. However, a lot of errors remain.

If you log into Travis (using your Github account) you can enable the stalker repository: https://travis-ci.org/profile
If you do, don't forget enable the "Build only if .travis.yml is present" setting or Travis will attempt to test all your branches.

I mentioned it in the previous PR but Travis testing is 100% free for public repositories so you don't have to worry about any expenses. It's quite a fantastic service.

I also de-bumped the version number for the Postgres server to 9.3 just because that's the version I have. Doesn't matter much, probably.