### PR TITLE
Feature/appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
 install:
-  - gem install TaskJuggler
+  - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,4 +16,4 @@ install:
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 test_script:
-  - nosetests --verbose --with-doctest --with-process-isolation --exe
+  - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,6 @@ init:
   - SET PATH=C:\Ruby22\bin;%PATH%
   - ruby -v
   - gem -v
-  - SET PGUSER=stalker_admin
-  - SET PGPASSWORD=stalker
   - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   - psql --version
 
@@ -29,8 +27,8 @@ services:
   - postgresql93
 
 before_test:
-  - createdb --help
-  - createdb -U postgres stalker_test
+    - psql -c "CREATE DATABASE stalker_test;" -U postgres
+    - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,6 +15,8 @@ init:
   - SET PATH=C:\Ruby22\bin;%PATH%
   - ruby -v
   - gem -v
+  - SET PGUSER=postgres
+  - SET PGPASSWORD=Password12!
   - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   - psql --version
 
@@ -27,13 +29,11 @@ services:
   - postgresql93
 
 before_test:
-    # - psql -l
     - pg_isready
-    # - psql -c "CREATE DATABASE stalker_test;" -U postgres
-    # - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
-    - SET PGUSER=postgres
-    - SET PGPASSWORD=Password12!
     - createdb stalker_test
+    - psql -l
+    - psql -c "CREATE DATABASE stalker_test;" -U postgres
+    - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ services:
 
 before_test:
     - pg_isready
-    - createdb stalker_test
+    # - createdb stalker_test
     - psql -l
     - psql -c "CREATE DATABASE stalker_test;" -U postgres
     - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,9 @@ environment:
       PYTHON: "C:\\Python35-x64"
       RUBY_VERSION: "22"
 
+services:
+  - postgresql93
+
 init:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python --version
@@ -19,9 +22,6 @@ init:
   - SET PGPASSWORD=stalker
   - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   - psql --version
-
-services:
-  - postgresql93
 
 install:
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,28 +10,23 @@ environment:
       RUBY_VERSION: "22"
 
 init:
-  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
-  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
+  - python --version
+  - SET PATH=C:\Ruby22\bin;%PATH%
+  - ruby -v
+  - gem -v
+  - SET PGUSER=stalker_admin
+  - SET PGPASSWORD=stalker
+  - SET PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
+  - psql --version
 
 services:
   - postgresql93
 
 install:
-  - ruby -v
-  - SET PATH=C:\Ruby22\bin;%PATH%
-  - SET PGUSER=stalker_admin
-  - SET PGPASSWORD=stalker
-  - PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
-
-before_test:
-  - python --version
-  - ruby -v
-  - gem -v
-
-build_script:
   - createdb stalker_test
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,20 @@
+build: false
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_ARCH: "64"
+    - PYTHON: "C:\\Python35-x64"
+      PYTHON_ARCH: "64"
+
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+
+install:
+  # Install PySide
+  - "%PYTHON%/Scripts/pip.exe install -y sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+
+test_script:
+  - python build_caveats_tests.py
+  - nosetests --verbose --with-doctest --with-process-isolation --exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,19 +22,15 @@ init:
 
 install:
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
-  # - gem install taskjuggler
-  # - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+  - gem install taskjuggler
+  - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 services:
   - postgresql93
 
 before_test:
-    - pg_isready
-    # - createdb stalker_test
-    - psql -l
     - psql -c "CREATE DATABASE stalker_test;" -U postgres
     - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
-
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ init:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
 install:
+  - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,10 @@ before_test:
     - pg_isready
     # - psql -c "CREATE DATABASE stalker_test;" -U postgres
     # - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
+    - SET PGUSER=postgres
+    - SET PGPASSWORD=Password12!
     - createdb stalker_test
+
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ init:
 
 install:
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
-  - gem install taskjuggler
-  - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+  # - gem install taskjuggler
+  # - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 services:
   - postgresql93

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,5 +16,4 @@ install:
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 test_script:
-  - python build_caveats_tests.py
   - nosetests --verbose --with-doctest --with-process-isolation --exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,7 +27,7 @@ services:
   - postgresql93
 
 before_test:
-    - psql -l
+    # - psql -l
     - pg_isready
     # - psql -c "CREATE DATABASE stalker_test;" -U postgres
     # - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,7 @@ services:
   - postgresql93
 
 before_test:
-  - createdb stalker_test
+  - createdb stalker_test -U postgres
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,12 @@ build: false
 
 environment:
   matrix:
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_ARCH: "64"
+    - PY27:
+      PYTHON: "C:\\Python27-x64"
       RUBY_VERSION: "22-x64"
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_ARCH: "64"
-      RUBY_VERSION: "22-x64"
+    - PY35:
+      PYTHON: "C:\\Python35-x64"
+      RUBY_VERSION: "22"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   matrix:
     - PY27:
       PYTHON: "C:\\Python27-x64"
-      RUBY_VERSION: "22-x64"
+      RUBY_VERSION: "22"
     - PY35:
       PYTHON: "C:\\Python35-x64"
       RUBY_VERSION: "22"
@@ -17,6 +17,8 @@ services:
   - postgresql93
 
 install:
+  - ruby -v
+  - SET PATH=C:\Ruby22\bin;%PATH%
   - SET PGUSER=stalker_admin
   - SET PGPASSWORD=stalker
   - PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,14 +20,17 @@ install:
   - SET PGUSER=stalker_admin
   - SET PGPASSWORD=stalker
   - PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
-  - createdb stalker_test
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 before_test:
+  - python --version
   - ruby -v
   - gem -v
+
+build_script:
+  - createdb stalker_test
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,6 +31,7 @@ before_test:
     - pg_isready
     # - psql -c "CREATE DATABASE stalker_test;" -U postgres
     # - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
+    - createdb stalker_test
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,7 @@ init:
 
 install:
   # Install PySide
-  - "%PYTHON%/Scripts/pip.exe install -y sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+  - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 test_script:
   - python build_caveats_tests.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,10 @@ services:
   - postgresql93
 
 before_test:
-    - psql -c "CREATE DATABASE stalker_test;" -U postgres
-    - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
+    - psql -l
+    - pg_isready
+    # - psql -c "CREATE DATABASE stalker_test;" -U postgres
+    # - psql -c "CREATE USER stalker_admin WITH PASSWORD 'stalker';" -U postgres
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,17 +4,30 @@ environment:
   matrix:
     - PYTHON: "C:\\Python27-x64"
       PYTHON_ARCH: "64"
+      RUBY_VERSION: "22-x64"
     - PYTHON: "C:\\Python35-x64"
       PYTHON_ARCH: "64"
+      RUBY_VERSION: "22-x64"
 
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
+services:
+  - postgresql93
+
 install:
+  - SET PGUSER=stalker_admin
+  - SET PGPASSWORD=stalker
+  - PATH=C:\Program Files\PostgreSQL\9.3\bin\;%PATH%
+  - createdb stalker_test
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+
+before_test:
+  - ruby -v
+  - gem -v
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,7 +29,8 @@ services:
   - postgresql93
 
 before_test:
-  - createdb stalker_test -U postgres
+  - createdb --help
+  - createdb -U postgres stalker_test
 
 test_script:
   - nosetests --verbosity=1 --cover-erase --with-coverage --cover-package=stalker

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ init:
   - "SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
 
 install:
-  # Install PySide
+  - gem install TaskJuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,9 +9,6 @@ environment:
       PYTHON: "C:\\Python35-x64"
       RUBY_VERSION: "22"
 
-services:
-  - postgresql93
-
 init:
   - SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%
   - python --version
@@ -27,6 +24,11 @@ install:
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
   - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage"
+
+services:
+  - postgresql93
+
+before_test:
   - createdb stalker_test
 
 test_script:


### PR DESCRIPTION
This PR makes [Appveyor](https://appveyor.com) perform the nosetests on Windows for both Python 2.7 and Python 3.5.

Just like with Travis CI, Appveyor is 100% free for public Github repositories. 👍 

And just like with Travis CI, you need to log into Appveyor's website and enable the `eoyilmaz/stalker` repository and preferably disable testing for branches which do not have the `appveyor.yml` file.

Here's the output of these tests for my latest commit: https://ci.appveyor.com/project/fredrikaverpil/stalker

Just like with the Travis CI PR, this do not change any of the Stalker files. It just adds a new YAML file for the Appveyor VM.

These CI services are a great way to proof PRs and any commits to the repository, really.