### PR TITLE
Add universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -25,3 +25,6 @@ domain = stalker
 input_file = stalker/locale/stalker.pot
 output_dir = stalker/locale
 previous = true
+
+[bdist_wheel]
+universal=1


### PR DESCRIPTION
It is my understanding that Stalker is Python-only and using the same codebase for Python 2.x and 3.x and could therefore offer the very same wheel for both these Python versions.

Currently, if you download the stalker wheel from PyPi, you'll get one of the following, depending on which version of pip you used and which platform you're on:

* stalker-0.2.18-py2-none-any.whl
* stalker-0.2.18-py3-none-any.whl
* stalker-0.2.18-cp27-none-any.whl
* stalker-0.2.18-cp35-none-any.whl

This PR attempts to fix that by instead making PyPi always serve one single, universal wheel file:

* stalker-0.2.18-py2.py3-none-any.whl