### PR TITLE
Require psycopg2-binary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@
 
     install:
       - gem install taskjuggler
-      - pip install sqlalchemy psycopg2 jinja2 alembic Mako MarkupSafe python-editor pytz tzlocal pytest pytest-xdist pytest-cov codeclimate-test-reporter
+      - pip install sqlalchemy psycopg2-binary jinja2 alembic Mako MarkupSafe python-editor pytz tzlocal pytest pytest-xdist pytest-cov codeclimate-test-reporter
       - pip install pytest --upgrade
 
     before_script:

--- a/Dockerfile-py2.7
+++ b/Dockerfile-py2.7
@@ -26,7 +26,7 @@ RUN apt-get update && \
     gem install taskjuggler && \
 
     pip install -U pip && \
-    pip install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage
+    pip install sqlalchemy psycopg2-binary jinja2 alembic mako markupsafe python-editor nose coverage
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``

--- a/Dockerfile-py3.5
+++ b/Dockerfile-py3.5
@@ -26,7 +26,7 @@ RUN apt-get update && \
     gem install taskjuggler && \
 
     pip3 install -U pip && \
-    pip3 install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor nose coverage
+    pip3 install sqlalchemy psycopg2-binary jinja2 alembic mako markupsafe python-editor nose coverage
 
 # Note: The official Debian and Ubuntu images automatically ``apt-get clean``
 # after each ``apt-get``

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ init:
 install:
   - gem install mime-types -v 2.6.2  # Required to install taskjuggler
   - gem install taskjuggler
-  - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2 jinja2 alembic mako markupsafe python-editor coverage pytz tzlocal pytest pytest-xdist pytest-cov"
+  - "%PYTHON%/Scripts/pip.exe install sqlalchemy psycopg2-binary jinja2 alembic mako markupsafe python-editor coverage pytz tzlocal pytest pytest-xdist pytest-cov"
 
 services:
   - postgresql95

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ CLASSIFIERS = ["Programming Language :: Python",
                "Topic :: Utilities",
                "Topic :: Office/Business :: Scheduling", ]
 INSTALL_REQUIRES = [
-    'psycopg2', 'sqlalchemy', 'alembic', 'jinja2', 'pytz', 'tzlocal',
+    'psycopg2-binary', 'sqlalchemy', 'alembic', 'jinja2', 'pytz', 'tzlocal',
 ]
 TEST_REQUIRES = ['pytest', 'pytest-xdist', 'pytest-cov', 'coverage']
 DATA_FILES = [(


### PR DESCRIPTION
Fix #66 

This changes the requirement of `psycopg2` to`psycopg2-binary`, which will make it easier to get the installation to complete on e.g. CentOS 7 without requiring `pg_config`.